### PR TITLE
725: Move dep -> purl conversion rules to specification

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -184,7 +184,7 @@ Specifying external dependencies
 Concrete package specification
 ''''''''''''''''''''''''''''''
 
-`PURLs <PURL>`__ implement a scheme for identifying packages that is meant to be portable
+A `PURL`_ implements a scheme for identifying packages that is meant to be portable
 across packaging ecosystems. Its design is::
 
     scheme:type/namespace/name@version?qualifiers#subpath


### PR DESCRIPTION
Also some small corrections and added links

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--22.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->