### PR TITLE
725: Add pyproject-external examples to Reference Implementation

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -838,4 +838,5 @@ CC0-1.0-Universal license, whichever is more permissive.
 .. _delvewheel: https://github.com/adang1345/delvewheel
 .. _verspurl: https://github.com/package-url/purl-spec/issues/386
 .. _rgommers/external-deps-build: https://github.com/rgommers/external-deps-build
+.. _pyproject-external: https://github.com/jaimergp/pyproject-external
 .. _Reference LAPACK: https://github.com/Reference-LAPACK/lapack

--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -636,10 +636,12 @@ there will not be code implementing the metadata spec as a whole. However,
 there are parts that do have a reference implementation:
 
 1. The ``[external]`` table has to be valid TOML and therefore can be loaded
-   with ``tomllib``.
+   with ``tomllib``. This table can be further processed with the
+   `pyproject-external`_ package, demonstrated below.
 2. The PURL specification, as a key part of this spec, has a Python package
    with a reference implementation for constructing and parsing PURLs:
-   `packageurl-python`_. The ``dep:`` URLs can be handled with this package.
+   `packageurl-python`_. This package is wrapped in `pyproject-external`_
+   to provide ``dep:``-specific validation and handling.
 
 There are multiple possible consumers and use cases of this metadata, once
 that metadata gets added to Python packages. Tested metadata for all of the
@@ -647,6 +649,64 @@ top 150 most-downloaded packages from PyPI with published platform-specific
 wheels can be found in `rgommers/external-deps-build`_. This metadata has
 been validated by using it to build wheels from sdists patched with that
 metadata in clean Docker containers.
+
+Example
+-------
+
+Given a ``pyproject.toml`` with this ``[external]`` table:
+
+.. code-block:: toml
+
+  [external]
+  build-requires = [
+    "dep:virtual/compiler/c",
+    "dep:virtual/compiler/rust",
+    "dep:generic/pkg-config",
+  ]
+  host-requires = [
+    "dep:generic/openssl",
+    "dep:generic/libffi",
+  ]
+
+You can use ``pyproject_external.External`` to parse it and manipulate it:
+
+.. code-block:: python
+
+  >>> from pyproject_external import External
+  >>> external = External.from_pyproject_path("./pyproject.toml")
+  >>> external.validate()
+  >>> external.to_dict()
+  {'external': {'build_requires': ['dep:virtual/compiler/c', 'dep:virtual/compiler/rust', 'dep:generic/pkg-config'], 'host_requires': ['dep:generic/openssl', 'dep:generic/libffi']}}
+  >>> external.build_requires
+  [DepURL(type='virtual', namespace='compiler', name='c', version=None, qualifiers={}, subpath=None), DepURL(type='virtual', namespace='compiler', name='rust', version=None, qualifiers={}, subpath=None), DepURL(type='generic', namespace=None, name='pkg-config', version=None, qualifiers={}, subpath=None)]
+  >>> external.build_requires[0]
+  DepURL(type='virtual', namespace='compiler', name='c', version=None, qualifiers={}, subpath=None)
+
+Note the proposed ``[external]`` table was well-formed. With invalid contents such as:
+
+.. code-block:: toml
+
+  [external]
+  build-requires = [
+    "dep:this-is-missing-the-type",
+    "pkg:not-a-dep-url"
+  ]
+
+You would fail the validation:
+
+.. code-block:: python
+
+  >>> external = External.from_pyproject_data(
+    {
+      "external": {
+        "build_requires": [
+          "dep:this-is-missing-the-type",
+          "pkg:not-a-dep-url"
+        ]
+      }
+    }
+  )
+  ValueError: purl is missing the required type component: 'dep:this-is-missing-the-type'.
 
 
 Rejected Ideas


### PR DESCRIPTION


<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--29.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->