### PR TITLE
Reword 'cross-compiling compilers'

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -148,7 +148,7 @@ so care must be taken when comparing build/host dependencies in
 ``pyproject.toml`` to dependencies from other package managers.
 
 Note that "target machine" or "target dependency" are not used in this PEP. That
-is typically only relevant for cross-compiling compilers or other such advanced
+is typically only relevant for cross-compiling a compiler or other such advanced
 scenarios [#gcc-cross-terminology]_, [#meson-cross]_ -- this is out of scope for
 this PEP.
 


### PR DESCRIPTION
A suggestion made in https://discuss.python.org/t/pep-725-specifying-external-dependencies-in-pyproject-toml/31888/85.