### PR TITLE
725: Extend Rejected ideas

### DIFF
--- a/peps/pep-0725.rst
+++ b/peps/pep-0725.rst
@@ -870,15 +870,39 @@ those, and if it's not present on the system then install the PyPI package for
 it. The authors believe that specific support for this scenario is not
 necessary (or too complex to justify such support); a dependency provider for
 external dependencies can treat PyPI as one possible source for obtaining the
-package.
+package. An example mapping for this use case is proposed in *name mapping PEP*.
 
 Using library and header names as external dependencies
 -------------------------------------------------------
 
 A previous draft PEP (`"External dependencies" (2015) <https://github.com/pypa/interoperability-peps/pull/30>`__)
 proposed using specific library and header names as external dependencies. This
-is too granular; using package names is a well-established pattern across
-packaging ecosystems and should be preferred.
+is both too granular, and insufficient (headers are often unversioned). Using
+package names is a well-established pattern across packaging ecosystems
+and should be preferred.
+
+Splitting host dependencies with explicit ``-dev`` or ``-devel`` suffixes
+-------------------------------------------------------------------------
+
+This convention is not consistent across all ecosystems and is thus impossible
+to implement robustly for all of them. Instead the ``build``, ``host`` and
+``run`` categories are proposed, with tools being in charge of which category
+applies to each case in a context-dependent way. If this proves to be
+insufficient, the URL design adopted by PURL and hence ``dep:`` identifiers
+allows extensions via qualifiers (``?key=value``) that can be adopted for
+manual overrides in further work.
+
+Identifier indirections
+-----------------------
+
+Some ecosystems have methods to select packages based on parametrized functions
+like ``cmake("dependency")`` or ``compiler("language")``, which return package
+names based on some additional context or configuration. This is not well-established
+across all ecosystems, and prone to change meaning over time. The authors prefer static
+identifiers that can be mapped explicitly via known metadata (e.g. as proposed in *name mapping PEP*).
+
+Ecosystems that do implement these indirections can use them to support the infrastructure
+designed to generate the mappings proposed in *name mapping PEP*.
 
 Adding a ``host-requires`` key under ``[build-system]``
 -------------------------------------------------------


### PR DESCRIPTION
- Reject identifier indirections (`cmake(...)`)
- Reject `-dev/-devel` splits
- Adjust rejection for header names as identifiers