### PR TITLE
Name mapping PEP: More rejected Ideas

### DIFF
--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -159,7 +159,7 @@ this could be made both more comprehensive and easier to maintain though a tool
 command with semantics of *"show this ecosystem's preferred package manager
 install command for all external dependencies"*. This may be done as a
 standalone tool, or as a new subcommand in any Python development workflow tool
-(e.g., Pip, Poetry, Hatch, PDM).
+(e.g., Pip, Poetry, Hatch, PDM, uv).
 
 
 Registry design

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -885,7 +885,7 @@ Reference Implementation
 
 A reference implementation should include three components:
 
-1. A central registry that captures at a minimum a ``dep:`` identifier and its description. This registry should
+1. A central registry that captures at a minimum a ``dep:`` identifier and its description. This registry MUST
    NOT contain specifics of package ecosystem mappings.
 2. A standard specification for a collection of mappings. JSON Schema is widely used for schema
    in many text editors, and would be a natural choice for expression of the standard specification.
@@ -897,10 +897,10 @@ An example registry can be found at https://github.com/jaimergp/external-metadat
 For (2), the JSON Schema is defined at https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/external-mapping.schema.json.
 For (3), a collection of example mappings for a sample of packages can be found at https://github.com/jaimergp/external-metadata-mappings/tree/main/data.
 
-The JSON Schemas are created with this Pydantic model (https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/schema.py).
+The JSON Schemas are created with `this Pydantic model <https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/schema.py>`__.
 
-An example Python API, ``external-metadata-mappings``, to consume the different JSON documents
-can be found at https://github.com/jaimergp/external-metadata-mappings.
+An example Python API to consume the different JSON documents can be found in 
+`pyproject-external <https://github.com/jaimergp/pyproject-external>`__.
 
 A prototype proof of concept implementation was contributed to Grayskull, a conda recipe generator for
 Python packages, via `conda/grayskull#518 <https://github.com/conda/grayskull/pull/518>`__.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -194,16 +194,16 @@ Specification
 Three schemas are proposed:
 
 1. A central registry of known ``dep:`` identifiers, as introduced in PEP 725.
-2. A list of known ecosystems and their package manager names.
+2. A list of known ecosystems and the location of their mappings.
 3. The ecosystem-specific mappings of ``dep:`` identifiers to their
    corresponding ecosystem specifiers, plus details of their package manager(s).
 
 The central registry defines which identifiers are recognized as canonical,
 plus known aliases. Each entry MUST provide a valid ``dep:`` identifier in the
 field ``id``, with an optional free form ``description`` text. Additionally
-some entries MAY refer to another entry via the ``provides`` field, which takes
-a string or a list of strings already defined as ``id`` in the registry. This is useful for
-aliases (e.g. ``dep:generic/arrow`` and ``dep:github/apache/arrow``), and
+an entry MAY refer to another entry via its ``provides`` field, which takes
+a string or a list of strings already defined as ``id`` in the registry. This is useful
+for both aliases (e.g. ``dep:generic/arrow`` and ``dep:github/apache/arrow``) and
 concrete implementations of a ``dep:virtual/`` entry (e.g. ``dep:generic/gcc``
 would provide ``dep:virtual/compiler/c``). Entries without ``provides`` content
 or, if populated, only with ``dep:virtual/`` identifiers, are considered
@@ -225,7 +225,7 @@ main content is a list of dictionaries, in which each entry consists of:
     identifiers as needed as build-, host- and runtime dependencies (see PEP 725 for
     details on these definitions).
 
-  - for convenience,  a string or a list of strings are also accepted as a
+  - for convenience, a string or a list of strings are also accepted as a
     shorthand form. In this case, the identifier(s) will be used to populate
     the three categories mentioned in the item above.
 
@@ -239,7 +239,7 @@ main content is a list of dictionaries, in which each entry consists of:
   dictionary that maps a string to a URL. This is useful to link to external
   resources that provide more information about the mapped packages.
 
-Some examples from the conda-forge mapping include:
+Some examples from a hypothetical conda-forge mapping would include:
 
 .. code-block:: js
 
@@ -290,9 +290,9 @@ Some examples from the conda-forge mapping include:
 
 The mappings MAY also specify another section ``package_managers``, reporting
 which package managers are available in the ecosystem. This field MUST
-take a dictionary with the following fields:
+take a list of dictionaries, with each of them reporting the following fields:
 
-- ``name`` (string), usually the name of the package manager executable
+- ``name`` (string), usually the name of the package manager executable.
 - ``install_command`` (list of strings), the command to run to install the mapped package(s).
 - ``version_operators``: a mapping of PEP 440 operator names to the relevant
   syntax for this package manager.
@@ -574,7 +574,7 @@ Each entry in this list is defined as:
     * - Required
       - True
 
-Each entry in this list is defined as:
+Each entry in this list is defined as a dictionary with these fields:
 
 .. list-table::
     :header-rows: 1

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -20,6 +20,9 @@ This PEP specifies a name mapping mechanism that allows packaging tools to map
 canonical PyPI and external dependency identifiers to their counterparts
 in other package repositories.
 
+.. JRG: Are we mapping PyPI identifiers here? I don't think so, right? I think the
+   abstract should just say "... to map external dependency identifiers (as introduced
+   in PEP 725) to..."
 
 Motivation
 ==========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -779,7 +779,7 @@ How to Teach This
 There are at least four audiences that need to learn a workflow here.
 
 1. Python package maintainers wishing to express an external dependency.
-2. Package ecosystem maintainers, who are responsible for keeping the
+2. Packaging ecosystem maintainers, who are responsible for keeping the
    mapping for their ecosystem current.
 3. Core registry maintainers, who are responsible for curating the central
    repository of ``dep:`` identifiers and descriptors.
@@ -828,16 +828,16 @@ Package ecosystem maintainers usage
 Any packages that express a ``dep:`` identifier that does not have a mapping in a given package
 ecosystem might not be able to provide tailored error messages and other UX affordances for end users.
 It is thus recommended that each package ecosystem maintain their mappings. Key to this will
-be automation. Some ideas for automation are:
+be automation. Some ideas for opt-in automation are:
 
-- Alert mapping maintainers whenever a new ``dep:`` identifier is added to the registry (probably noisy).
+- Alert mapping maintainers whenever a new ``dep:`` identifier is added to the registry (maybe noisy).
 - Provide tools that allow maintainers to diff their mappings to the registry contents to
   quickly identify missing entries.
 - Provide automated tooling that submits PRs to known mapping locations, such that maintainers
   need only fill in the ecosystem package name.
 - Provide status for each ``dep:`` identifier, to readily identify which ``dep:`` identifiers need attention.
 
-This maintenance is likely to be a lot of work to establish the initial mapping, but ideally small
+This maintenance is likely to involve a lot of work to establish the initial mapping, but ideally become small
 on an ongoing basis.
 
 
@@ -857,12 +857,17 @@ especially when it comes to dependencies where a number of synonyms are commonly
 used. This does not apply to ``dep:virtual/*`` identifiers, where a single canonical
 form is proposed and no additional aliases are allowed.
 
+Having client-side validation when the Python project is being packaged and/or uploaded
+to PyPI may help keep the maintenance efforts contained, since end-users can be pointed
+to the recommended identifiers.
+
 End user package consumers
 --------------------------
 
 There will be no change in user experience by default. End users do not need to know about
 this mechanism unless they opt in, which they may want to do to, for example, reduce their
-bandwidth and disk space usage.
+bandwidth and disk space usage. This is particularly true if the user only relies on wheels,
+since the only impact will be driven by external runtime dependencies.
 
 If they do opt-in, in an ideal case these package install commands can be done transparently,
 and the user experience remains unchanged. There are several foreseeable issues that will arise,

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -899,7 +899,7 @@ For (3), a collection of example mappings for a sample of packages can be found 
 
 The JSON Schemas are created with `this Pydantic model <https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/schema.py>`__.
 
-An example Python API to consume the different JSON documents can be found in 
+An example Python API to consume the different JSON documents can be found in
 `pyproject-external <https://github.com/jaimergp/pyproject-external>`__.
 
 A prototype proof of concept implementation was contributed to Grayskull, a conda recipe generator for

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1016,6 +1016,17 @@ Hence, we propose that the central authority only governs the central registry a
 the list of known ecosystems, while the maintenance of the mappings themselves is handled
 by the target ecosystems. More details are given in Rationale and Governance.
 
+Allowing ecosystem-specific variants of packages
+------------------------------------------------
+
+Some ecosystems have their own variants of known packages; e.g. Debian's
+``libsymspg2-dev``. While an identifier such as ``dep:debian/libsymspg2-dev``
+is syntactically valid, the central registry should not recognize it as a
+well-known identifier, preferring its ``generic`` counterpart instead. Users
+may still choose to use it, but tools may warn about it and suggest using the
+generic one. This is meant to encourage ecosystem agnostic metadata whenever
+possible to facilitate adoption across platforms and operating systems.
+
 
 Open Issues
 ===========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -653,14 +653,11 @@ Practical cases
 ^^^^^^^^^^^^^^^
 
 The following examples illustrate how the name mapping mechanism may be used.
-Note that the ``py-show`` command is hypothetical; this could be a ``pip``
-command or implemented in a new tool with a different name.
+They use the CLI implemented as part of the ``pyproject-external`` package.
 
-.. JRG: Should we change this to use pyproject-external or leave it as a hypothethical CLI?
-
-Say we have a Python package named ``my-cxx-pkg`` with a single extension
-module, implemented in C++ and using Boost and ``pybind11``, plus
-``meson-python`` as the build backend:
+Say we have cloned the source of a Python package named ``my-cxx-pkg`` with a
+single extension module, implemented in C++, linking to ``zlib``, using ``pybind11``,
+plus ``meson-python`` as the build backend:
 
 .. code:: toml
 
@@ -674,7 +671,9 @@ module, implemented in C++ and using Boost and ``pybind11``, plus
     [external]
     build-requires = [
       "dep:virtual/compiler/cxx",
-      "dep:generic/boost",
+    ]
+    host-requires = [
+      "dep:generic/zlib",
     ]
 
 With complete name mappings for ``apt`` on Ubuntu, this may then show the
@@ -682,24 +681,32 @@ following:
 
 .. code:: bash
 
-    $ # show all PyPI dependencies
-    $ py-show --pypi
-    meson-python
-    pybind11
 
-    $ # show all external dependencies
-    $ py-show --external
-    dep:virtual/compiler/cxx
-    dep:generic/boost
+    # show all external dependencies as dep: URLs
+    $ python -m pyproject_external show .
+    [external]
+    build-requires = [
+        "dep:virtual/compiler/cxx",
+    ]
+    host-requires = [
+        "dep:generic/zlib",
+    ]
 
-    $ # show how to install external dependencies
-    $ py-show --external --system-install-cmd
-    sudo apt install g++ libboost-all-dev
+    # show all external dependencies, but mapped to the autodetected ecosystem
+    $ python -m pyproject_external show --output=mapped .
+    [external]
+    build_requires = [
+        "g++",
+        "python3",
+    ]
+    host_requires = [
+        "zlib1g",
+        "zlib1g-dev",
+    ]
 
-    $ # show install command for both PyPI and external dependencies
-    $ # this could include the Python dev headers too if those are missing
-    $ py-show --all --system-install-cmd
-    sudo apt install python3-dev g++ libboost-all-dev python3-mesonpy python3-pybind11 pybind11-dev
+    # show how to install external dependencies
+    $ python -m pyproject_external show --output=command .
+    sudo apt install --yes g++ zlib1g zlib1g-dev python3
 
 We have not yet run those install commands, so the external dependency may be
 missing. If we get a build failure, the output may look like:
@@ -717,7 +724,7 @@ missing. If we get a build failure, the output may look like:
     on your system they are likely to be the cause of this build failure:
 
       dep:virtual/compiler/cxx
-      dep:generic/boost
+      dep:generic/zlib
 
 If Pip has implemented support for querying the name mapping registry, the end
 of that message could improve to:
@@ -728,22 +735,23 @@ of that message could improve to:
     mentioned above. You may need to install them with `apt`:
 
       g++
-      libboost-all-dev
+      zlib1g
+      zlib1g-dev
 
 If the user wants to use conda packages and the ``mamba`` package manager to
-install external dependencies, they may specify that in a hypothetical
-``~/.pypi-name-mappings`` file:
+install external dependencies, they may specify that in their
+``~/.config/pyproject-external/config.toml`` file:
 
-.. code::
+.. code:: toml
 
-    system-package-manager: mamba
+    preferred_package_manager = "mamba"
 
-This will then change the output of ``py-show``:
+This will then change the output of ``pyproject-external``:
 
 .. code:: bash
 
-    $ py-show --all --system-install-cmd
-    mamba install cxx-compiler libboost-devel
+    $ python -m pyproject_external show --output command .
+    mamba install --yes --channel=conda-forge --channel-priority=strict cxx-compiler zlib python
 
 In order to use the name mappings for the recipe generator of our package, we
 can now run Grayskull_:

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1094,7 +1094,7 @@ case *require* such checks.
 It is expected that as the ``[external]`` metadata tables are adopted by the
 packaging community, the *canonical* identifier list grows to accommodate the
 requirements found in different projects. For example, a new C++ library or a
-new compiler are introduced.
+new language compiler are introduced.
 
 If validation is made too strict and rejects unknown identifiers, this would
 introduce unnecessary friction in the external metadata adoption, and require

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1055,24 +1055,24 @@ the same schemas can be repurposed to that end. After all, it is trivial to buil
 mapping maintainer could annotate their repackaging efforts with the source PURL identifier,
 and then use that metadata to generate compatible mappings, such as:
 
-```json
-{
-  "$schema": "https://raw.githubusercontent.com/jaimergp/external-metadata-mappings/main/schemas/external-mapping.schema.json",
-  "schema_version": 1,
-  "name": "PyPI packages in Ubuntu 24.04",
-  "description": "PyPI mapping for the Ubuntu 24.04 LTS (Noble) distro",
-  "mappings": [
+.. code:: json
+
     {
-      "id": "dep:pypi/numpy",
-      "description": "The fundamental package for scientific computing with Python",
-      "specs": ["python3-numpy"],
-      "urls": {
-        "home": "https://numpy.org/"
-      }
+      "$schema": "https://raw.githubusercontent.com/jaimergp/external-metadata-mappings/main/schemas/external-mapping.schema.json",
+      "schema_version": 1,
+      "name": "PyPI packages in Ubuntu 24.04",
+      "description": "PyPI mapping for the Ubuntu 24.04 LTS (Noble) distro",
+      "mappings": [
+        {
+          "id": "dep:pypi/numpy",
+          "description": "The fundamental package for scientific computing with Python",
+          "specs": ["python3-numpy"],
+          "urls": {
+            "home": "https://numpy.org/"
+          }
+        }
+      ]
     }
-  ]
-}
-```
 
 Such a mapping would allow downstream redistribution efforts to focus on the
 compiled packages and instead delegate pure wheels to Python packaging

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -770,6 +770,9 @@ Security Implications
 
 TBD.
 
+.. JRG: Something about arbitrary command execution, untrusted mappings,
+   and superuser permissions being required in some systems.
+
 How to Teach This
 =================
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -630,7 +630,7 @@ Each entry in this list is defined as a dictionary with these fields:
 Examples
 --------
 
-This prototype repository provides examples of how these schemas would look like in real cases:
+The following repository provides examples of how these schemas would look like in real cases:
 
 - `Central registry <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/registry.json>`__.
 - `Known ecosystems <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/known-ecosystems.json>`__.
@@ -649,8 +649,8 @@ This prototype repository provides examples of how these schemas would look like
   - `Vcpkg <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/vcpkg.mapping.json>`__.
   - `Winget <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/winget.mapping.json>`__.
 
-Practical cases
-^^^^^^^^^^^^^^^
+pyproject-external CLI
+^^^^^^^^^^^^^^^^^^^^^^
 
 The following examples illustrate how the name mapping mechanism may be used.
 They use the CLI implemented as part of the ``pyproject-external`` package.
@@ -680,7 +680,6 @@ With complete name mappings for ``apt`` on Ubuntu, this may then show the
 following:
 
 .. code:: bash
-
 
     # show all external dependencies as dep: URLs
     $ python -m pyproject_external show .
@@ -752,6 +751,79 @@ This will then change the output of ``pyproject-external``:
 
     $ python -m pyproject_external show --output command .
     mamba install --yes --channel=conda-forge --channel-priority=strict cxx-compiler zlib python
+
+
+Having a central registry enables client-side validation of the ``[external]``
+table of any given project. The key idea behind the validation is to disallow
+``dep:`` identifiers that are not included in the central registry and to
+recommend using the canonical form instead of a secondary alias. The
+``pyproject-external`` project provides a simple way to do so:
+
+.. code-block:: bash
+
+    $ python -m pyproject_external show --validate grpcio-1.71.0.tar.gz
+    WARNING  Dep URL 'dep:virtual/compiler/cpp' is not recognized in the
+    central registry. Did you mean any of ['dep:virtual/compiler/c',
+    'dep:virtual/compiler/cxx', 'dep:virtual/compiler/cuda',
+    'dep:virtual/compiler/go', 'dep:virtual/compiler/c-sharp']?
+    [external]
+    build-requires = [
+        "dep:virtual/compiler/c",
+        "dep:virtual/compiler/cpp",
+    ]
+
+
+pyproject-external API
+^^^^^^^^^^^^^^^^^^^^^^
+
+The proposed Python API also allows users to do these operations programmatically:
+
+.. code-block:: python
+
+    >>> from pyproject_external import External
+    >>> external = External.from_pyproject_data(
+          {
+            "external": {
+              "build-requires": [
+                "dep:virtual/compiler/c",
+                "dep:virtual/compiler/cpp",
+              ]
+            }
+          }
+        )
+    >>> external.validate()
+    Dep URL 'dep:virtual/compiler/cpp' is not recognized in the central registry. Did you
+    mean any of ['dep:virtual/compiler/c', 'dep:virtual/compiler/cxx',
+    'dep:virtual/compiler/cuda', 'dep:virtual/compiler/go', 'dep:virtual/compiler/c-sharp']?
+    >>> external = External.from_pyproject_data(
+          {
+            "external": {
+              "build-requires": [
+                "dep:virtual/compiler/c",
+                "dep:virtual/compiler/cxx",  # fixed
+              ]
+            }
+          }
+        )
+    >>> external.validate()
+    >>> external.to_dict()
+    {'external': {'build_requires': ['dep:virtual/compiler/c', 'dep:virtual/compiler/cxx']}}
+    >>> from pyproject_external import detect_ecosystem_and_package_manager
+    >>> ecosystem, package_manager = detect_ecosystem_and_package_manager()
+    >>> ecosystem
+    'conda-forge'
+    >>> package_manager
+    'pixi'
+    >>> external.to_dict(mapped_for=ecosystem, package_manager=package_manager)
+    {'external': {'build_requires': ['c-compiler', 'cxx-compiler', 'python']}}
+    >>> external.install_command(ecosystem, package_manager=package_manager)
+    ['pixi', 'add', 'c-compiler', 'cxx-compiler', 'python']
+
+Grayskull
+^^^^^^^^^
+
+A prototype proof of concept implementation was contributed to Grayskull, a conda recipe generator for
+Python packages, via `conda/grayskull#518 <https://github.com/conda/grayskull/pull/518>`__.
 
 In order to use the name mappings for the recipe generator of our package, we
 can now run Grayskull_:
@@ -928,47 +1000,8 @@ For (3), a collection of example mappings for a sample of packages can be found 
 
 The JSON Schemas are created with `this Pydantic model <https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/schema.py>`__.
 
-An example Python API to consume the different JSON documents can be found in
-`pyproject-external <https://github.com/jaimergp/pyproject-external>`__.
-
-A prototype proof of concept implementation was contributed to Grayskull, a conda recipe generator for
-Python packages, via `conda/grayskull#518 <https://github.com/conda/grayskull/pull/518>`__.
-
-Having a central registry enables client-side validation of the ``[external]`` table of any given
-project. The key idea behind the validation is to disallow ``dep:`` identifiers that are not included
-in the central registry and to recommend using the canonical form instead of a secondary alias. The
-``pyproject-external`` project provides a simple way to do so:
-
-.. code-block:: bash
-
-    $ python -m pyproject_external --validate grpcio-1.71.0.tar.gz
-    WARNING  Dep URL 'dep:virtual/compiler/cpp' is not recognized in the central registry. Did you
-    mean any of ['dep:virtual/compiler/c', 'dep:virtual/compiler/cxx', 'dep:virtual/compiler/cuda',
-    'dep:virtual/compiler/go', 'dep:virtual/compiler/c-sharp']?
-    [external]
-    build-requires = [
-        "dep:virtual/compiler/c",
-        "dep:virtual/compiler/cpp",
-    ]
-
-The proposed Python API also allows users to do it programmatically:
-
-.. code-block:: python
-
-    >>> from pyproject_external import External
-    >>> external = External.from_pyproject_data(
-          {
-            "external": {
-              "build-requires": [
-                "dep:virtual/compiler/c",
-                "dep:virtual/compiler/cpp",
-              ]
-          }
-        )
-    >>> external.validate()
-    Dep URL 'dep:virtual/compiler/cpp' is not recognized in the central registry. Did you
-    mean any of ['dep:virtual/compiler/c', 'dep:virtual/compiler/cxx', 'dep:virtual/compiler/cuda',
-    'dep:virtual/compiler/go', 'dep:virtual/compiler/c-sharp']?
+The reference Python API to consume the different JSON documents and ``[external]`` tables
+can be found in `pyproject-external <https://github.com/jaimergp/pyproject-external>`__.
 
 Rejected Ideas
 ==============

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -198,9 +198,17 @@ or, if populated, only with ``dep:virtual/`` identifiers, are considered
 canonical. The ``provides`` field MUST NOT be present in ``dep:virtual/`` definitions.
 
 Having a central registry enables the validation of the ``[external]`` table.
-Tools MUST check that the provided identifiers are well formed. They MAY
-disallow ``dep:`` identifiers that are not included in the central registry,
-and SHOULD recommend using the canonical form instead of a secondary alias.
+All involved tools MUST check that the provided identifiers are well formed.
+Additionally, some tools MAY check whether the identifiers in use are recognized as
+canonical. More specifically:
+
+- Build backends and installers SHOULD NOT do any validation of names being
+  canonical by default.
+- Uploaders like ``twine`` SHOULD validate if the identifiers are canonical
+  and warn or report an error to the user, with opt-out mechanisms. They
+  SHOULD suggest a canonical replacement, if available.
+- Index servers like PyPI MAY perform the same validation as the uploaders and
+  reject the artifact if necessary.
 
 The list of known ecosystems assigns an identifier to each ecosystem and reports the
 canonical location for its mapping. The mappings specify which ecosystem-specific
@@ -1078,9 +1086,10 @@ solutions directly.
 Strict validation of identifiers
 --------------------------------
 
-With the central registry, tools could choose to reject ``[external]`` metadata
-entries that do not conform to the well-known identifiers. We have decided not to
-enforce this and instead suggest to simply warn about it.
+The central registry provides a list of canonical identifiers, which may tempt
+implementors into ensuring that all supplied identifiers are indeed canonical. We
+have decided to only *recommend* this practice for some tool categories, but in no
+case *require* such checks.
 
 It is expected that as the ``[external]`` metadata tables are adopted by the
 packaging community, the *canonical* identifier list grows to accommodate the

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1007,9 +1007,15 @@ can be found in `pyproject-external <https://github.com/jaimergp/pyproject-exter
 Rejected Ideas
 ==============
 
-- Centralized registry and mappings governed by the same body. While a central authority for the
-  registry is useful, the maintenance burden of handling the mappings for multiple ecosystems is
-  unfeasible at the scale of PyPI.
+Centralized mappings governed by the same body
+----------------------------------------------
+
+While a central authority for the registry is useful, the maintenance burden
+of handling the mappings for multiple ecosystems is unfeasible at the scale of PyPI.
+Hence, we propose that the central authority only governs the central registry and
+the list of known ecosystems, while the maintenance of the mappings themselves is handled
+by the target ecosystems. More details are given in Rationale and Governance.
+
 
 Open Issues
 ===========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -26,32 +26,32 @@ Motivation
 
 Packages on PyPI often require build-time and runtime dependencies that are not
 present on PyPI. :doc:`pep-0725` introduced metadata to express
-such dependencies. In order to make use of concrete external dependency metadata for
-a Python package, it is necessary to map given dependency identifiers to the names
+such dependencies. Using concrete external dependency metadata for
+a Python package requires mapping the given dependency identifiers to the specifiers
 used in other ecosystems.
 
 In the context of external dependencies, there are at least two key motivators:
 
-- Enable tools to automatically map external dependencies to packages in other
+- Enabling tools to automatically map external dependencies to packages in other
   packaging repositories/ecosystems,
-- Make it possible to include needed external dependencies *with the package
+- Including the needed external dependencies *with the package
   names used by the relevant system package manager on the user's system* in
   error messages emitted by Python package installers and build frontends,
-  as well as allow the user to query for those names directly to obtain install
+  as well as allowing the user to query for those names directly to obtain install
   instructions.
 
 Packaging ecosystems like Linux distros, conda, Homebrew, Spack, and Nix need
 full sets of dependencies for Python packages, and have tools like pyp2rpm_
 (Fedora), Grayskull_ (conda), and dh_python_ (Debian) which attempt to
-automatically generate dependency metadata automatically from the metadata in
+automatically generate dependency information from the metadata available in
 upstream Python packages. Before PEP 725, external dependencies were handled manually,
 because there was no metadata for this in ``pyproject.toml`` or any other
-standard metadata file. Enabling automating this conversion is a key benefit of
-this PEP, making packaging Python easier and more reliable. In addition, the
-authors envision other types of tools making use of this information, e.g.,
+standard metadata file. Enabling its automatic conversion is a key benefit of
+this PEP, making Python packaging easier and more reliable. In addition, the
+authors envision other types of tools making use of this information; e.g.,
 dependency analysis tools like Repology_, Dependabot_ and libraries.io_.
 
-It is also common that other ecosystems repackage Python projects with their own
+It is also common that other ecosystems redistribute Python projects with their own
 packaging system. While this is required for packages with compiled extensions, it
 is theoretically unnecessary for pure Python wheels. The mapping proposed in this PEP
 would allow downstream redistribution efforts to focus on the compiled packages and

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -202,8 +202,8 @@ All involved tools MUST check that the provided identifiers are well formed.
 Additionally, some tools MAY check whether the identifiers in use are recognized as
 canonical. More specifically:
 
-- Build backends and installers SHOULD NOT do any validation of names being
-  canonical by default.
+- Build backends, build frontends, and installers SHOULD NOT do any validation
+  of identifiers being canonical by default.
 - Uploaders like ``twine`` SHOULD validate if the identifiers are canonical
   and warn or report an error to the user, with opt-out mechanisms. They
   SHOULD suggest a canonical replacement, if available.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -67,21 +67,23 @@ Rationale
 Prior art
 ---------
 
-`R <https://github.com/rstudio/r-system-requirements>`__: The R system with a central
-registry knows how to translate external dependency metadata to install
+The R language has a `System Requirements for R packages
+<https://github.com/rstudio/r-system-requirements>`__ with a central
+registry that knows how to translate external dependency metadata to install
 commands for package managers like ``apt-get``. This registry centralises the
 mappings for a series of Linux distributions, and also Windows. macOS is not
-present. The `"Rule Coverage" of its README <https://github.com/rstudio/r-system-requirements/blob/7314012a48d38854c19f439e1c2d2e4b383fe7ea/README.md#rule-coverage>`__
-used to show that this system improves the chance
-of success of building packages from CRAN from source. Across all CRAN packages,
+present. The `"Rule Coverage" of its README
+<https://github.com/rstudio/r-system-requirements/blob/7314012a48d38854c19f439e1c2d2e4b383fe7ea/README.md#rule-coverage>`__
+used to show that this system improves the chance of success of building packages
+from CRAN from source. Across all CRAN packages,
 Ubuntu 18 improved from 78.1% to 95.8%, CentOS 7 from 77.8% to 93.7% and openSUSE
 15.0 from 78.2% to 89.7%. The chance of success depends on how well the registry
 is maintained, but the gain is significant: ~4x fewer packages fail to build on
 Ubuntu and CentOS in a Docker container.
 
-`Fedora/RPM <https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/117>`__:
-The ``NameConvertor`` implementation in pyp2rpm_ is based on rules, with the
-base one being that the RPM name for a PyPI package is
+RPM-based distributions, like Fedora, can use a `rule-based implementation
+<https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/117>`__
+(``NameConvertor``) in pyp2rpm_. The main rule is that the RPM name for a PyPI package is
 ``f"python-{pypi_package_name}"``. This seems to work quite well; there are a
 few variants like Python version specific names, where the prefix contains the
 Python major and minor version numbers (e.g. ``python311-`` instead of

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -643,6 +643,7 @@ The following repository provides examples of how these schemas would look like 
   - `Gentoo <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/gentoo.mapping.json>`__.
   - `Homebrew <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/homebrew.mapping.json>`__.
   - `Nix <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/nix.mapping.json>`__.
+  - `PyPI <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/pypi.mapping.json>`__.
   - `Scoop <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/scoop.mapping.json>`__.
   - `Spack <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/spack.mapping.json>`__.
   - `Ubuntu <https://github.com/jaimergp/external-metadata-mappings/blob/main/data/ubuntu.mapping.json>`__.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -294,6 +294,10 @@ take a list of dictionaries, with each of them reporting the following fields:
 
 - ``name`` (string), usually the name of the package manager executable.
 - ``install_command`` (list of strings), the command to run to install the mapped package(s).
+- ``query_command`` (list of strings), the command to check if the mapped package(s)
+  are already installed.
+- ``requires_elevation`` (bool, ``install`` or ``query``): whether the associated commands require
+  superuser permissions to run.
 - ``version_operators``: a mapping of PEP 440 operator names to the relevant
   syntax for this package manager.
 
@@ -590,9 +594,26 @@ Each entry in this list is defined as a dictionary with these fields:
       - True
     * - ``install_command``
       - ``list[string]``
-      - Command used to install the given packages. ``{}`` is a special placeholder
-        for the package names in ``specs``. If not provided, they are appended.
+      - Command that must be used to install the given package(s). Each
+        argument must be provided as a separate string, as in `subprocess.run`.
+        Use `{}` as a placeholder where the package specs must be injected, if
+        needed. If `{}` is not present, they will be added at the end.
       - True
+    * - ``query_command``
+      - ``list[string]``
+      - Command to check whether a package is installed. Each argument must be
+        provided as a separate string, as in `subprocess.run`. The `{}`
+        placeholder will be replaced by a single package spec, if needed.
+        Otherwise, the package specifier will be added at the end. An empty
+        list means no query command is available for this package manager.
+      - True
+    * - ``requires_elevation``
+      - ``bool | Literal['install', 'query']``
+      - Whether the install and query commands require elevated permissions to
+        run. Use ``True`` to require on all commands, ``False`` for none. ``install``
+        and ``query`` can be used individually to only require elevation on one
+        of them.
+      - False
     * - ``version_operators``
       - ``dict[Literal['and', 'arbitrary', 'compatible', 'equal', 'greater_than_equal', 'greater_than', 'less_than_equal', 'less_than', 'not_equal', 'separator'],  string]``
       - Mapping of PEP440 version comparison operators to the syntax used in this

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -124,9 +124,9 @@ package manager of choice (`example StackOverflow question <https://unix.stackex
 Maintenance costs of name mappings
 ----------------------------------
 
-The maintenance cost of name mappings from PyPI to a large number of packaging
+The maintenance cost of external dependency mappings to a large number of packaging
 ecosystems is potentially high. We choose to define the registry in such
-a way that these mappings can be maintained by the packaging ecosystems
+a way that these mappings can be maintained by the target packaging ecosystems
 themselves. Hence this system is opt-in for a given ecosystem,
 and the associated maintenance costs are distributed. Some ecosystems
 have such a name mapping already, because it's required for tools like pyp2rpm_

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1028,15 +1028,25 @@ A central registry should only contain a list of ``dep:`` URLs and a
 minimal set of metadata fields to facilitate its identification (a free-form
 text description, and one or more URLs to relevant locations).
 
-These fields should be enough to identify the project home,
-where that extra metadata can be obtained (e.g. the repository URL will likely
-include details about authorship and licensing). Also, those details may change
-over the lifetime of the project, and keeping them up-to-date would increase the
-maintenance burden on the governance body.
-
-Hence, we choose to leave these details out of the central registry, and instead
+We have chosen to leave additional details out of the central registry, and instead
 suggest external contributors to maintain their own mappings where they can
 annotate the identifiers with extra metadata via the free-form ``extra`` field.
+
+The reasons include:
+
+- The existing fields should be enough to identify the project home,
+  where that extra metadata can be obtained (e.g. the repository URL will likely
+  include details about authorship and licensing).
+- These details can also be obtained from the actual target ecosystems. In some
+  cases this might be even preferable; e.g. for licenses, where downstream packaging
+  can actually affect it by unvendoring dependencies or adjusting optional bits.
+- Those details may change over the lifetime of the project, and keeping them
+  up-to-date would increase the maintenance burden on the governance body.
+- Centralizing additional metadata would hence introduce ambiguities and
+  discrepancies across target ecosystems, where different versions may be
+  available or required.
+
+
 
 Mapping PyPI projects to repackaged counterparts in target ecosystems
 ---------------------------------------------------------------------

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -167,7 +167,8 @@ Registry design
 
 The mapping infrastructure should include the following components and properties:
 
-- A central registry for known generic and virtual PEP 725 identifiers (``dep:`` URLs).
+- A central registry of PEP 725 identifiers (``dep:`` URLs), including at least the
+  well-known generic and virtual identifiers considered canonical.
 - A list of known ecosystems and their package managers, where ecosystem maintainers
   can register their name mapping(s).
 - A standardized schema that defines how mappings should be structured.

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -704,7 +704,7 @@ of that message could improve to:
 .. code:: bash
 
     The following external dependencies are needed to install the package
-    mentioned above, and are not installed with `apt`:
+    mentioned above. You may need to install them with `apt`:
 
       g++
       libboost-all-dev

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -67,20 +67,20 @@ Rationale
 
 Prior art
 ---------
-R: https://github.com/rstudio/r-system-requirements. The R system with central
+
+`R <https://github.com/rstudio/r-system-requirements>`__: The R system with a central
 registry knows how to translate external dependency metadata to install
 commands for package managers like ``apt-get``. This registry centralises the
 mappings for a series of Linux distributions, and also Windows. macOS is not
 present. The `"Rule Coverage" of its README <https://github.com/rstudio/r-system-requirements/blob/7314012a48d38854c19f439e1c2d2e4b383fe7ea/README.md#rule-coverage>`__
-used to show that improves the chance
+used to show that this system improves the chance
 of success of building packages from CRAN from source. Across all CRAN packages,
-Ubuntu 18 improves from 78.1% to 95.8%, CentOS 7 from 77.8% to 93.7% and openSUSE
+Ubuntu 18 improved from 78.1% to 95.8%, CentOS 7 from 77.8% to 93.7% and openSUSE
 15.0 from 78.2% to 89.7%. The chance of success depends on how well the registry
-is maintained, but the gain is significant - ~4x fewer packages fail to build on
+is maintained, but the gain is significant: ~4x fewer packages fail to build on
 Ubuntu and CentOS in a Docker container.
 
-Fedora/RPM:
-https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/117?u=rgommers.
+`Fedora/RPM <https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/117>`__:
 The ``NameConvertor`` implementation in pyp2rpm_ is based on rules, with the
 base one being that the RPM name for a PyPI package is
 ``f"python-{pypi_package_name}"``. This seems to work quite well; there are a
@@ -107,7 +107,7 @@ The `OpenStack <https://www.openstack.org/>`__ ecosystem also needs to deal with
 some mapping efforts. All of them focus on Linux distributions, exclusively.
 `pkg-map <https://docs.openstack.org/diskimage-builder/latest/elements/pkg-map/README.html>`__
 accompanies ``diskimage-builder`` and provides a file format where the user defines
-arbitrary variable names and their corresponding name in the target distro
+arbitrary variable names and their corresponding names in the target distro
 (Red Hat, Debian, OpenSUSE, etc). See `example for PyYAML <https://github.com/stbenjam/diskimage-builder/blob/5bc5f8aff3b40b1918ce72660f1dba38c3c4f27a/diskimage_builder/elements/svc-map/pkg-map#L4>`__.
 `bindep <https://opendev.org/opendev/bindep>`__ defines a file ``bindep.txt``
 (see `example <https://opendev.org/opendev/bindep/src/branch/master/bindep/tests/bindep.txt>`__)

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -954,6 +954,7 @@ Open Issues
 References
 ==========
 
+- https://github.com/jaimergp/pyproject-external
 - https://github.com/rgommers/external-deps-build
 - https://github.com/jaimergp/external-metadata-mappings
 - https://github.com/conda/grayskull/pull/518

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -207,6 +207,11 @@ would provide ``dep:virtual/compiler/c``). Entries without ``provides`` content
 or, if populated, only with ``dep:virtual/`` identifiers, are considered
 canonical. The ``provides`` field MUST NOT be present in ``dep:virtual/`` definitions.
 
+Having a central registry enables client-side validation of the ``[external]``
+table of any given project. Tools SHOULD disallow ``dep:`` identifiers
+that are not included in the central registry and SHOULD recommend using the
+canonical form instead of a secondary alias.
+
 The list of known ecosystems assigns an identifier to each ecosystem and reports the
 canonical location for its mapping. The mappings specify which ecosystem-specific
 identifiers provide the canonical entries available in the central registry. Its
@@ -752,11 +757,8 @@ This will then change the output of ``pyproject-external``:
     mamba install --yes --channel=conda-forge --channel-priority=strict cxx-compiler zlib python
 
 
-Having a central registry enables client-side validation of the ``[external]``
-table of any given project. The key idea behind the validation is to disallow
-``dep:`` identifiers that are not included in the central registry and to
-recommend using the canonical form instead of a secondary alias. The
-``pyproject-external`` project provides a simple way to do so:
+The ``pyproject-external`` CLI also provides a simple way to perform
+``[external]`` table validation:
 
 .. code-block:: bash
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1034,8 +1034,8 @@ annotate the identifiers with extra metadata via the free-form ``extra`` field.
 
 The reasons include:
 
-- The existing fields should be enough to identify the project home,
-  where that extra metadata can be obtained (e.g. the repository URL will likely
+- The existing fields should be sufficient to identify the project home,
+  where that extra metadata can be obtained (e.g. the repository at the URL will likely
   include details about authorship and licensing).
 - These details can also be obtained from the actual target ecosystems. In some
   cases this might be even preferable; e.g. for licenses, where downstream packaging

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -17,12 +17,8 @@ Abstract
 ========
 
 This PEP specifies a name mapping mechanism that allows packaging tools to map
-canonical PyPI and external dependency identifiers to their counterparts
-in other package repositories.
-
-.. JRG: Are we mapping PyPI identifiers here? I don't think so, right? I think the
-   abstract should just say "... to map external dependency identifiers (as introduced
-   in PEP 725) to..."
+external dependency identifiers (as introduced in :doc:`pep-0725`) to their
+counterparts in other package repositories.
 
 Motivation
 ==========
@@ -679,10 +675,6 @@ plus ``meson-python`` as the build backend:
 
 With complete name mappings for ``apt`` on Ubuntu, this may then show the
 following:
-
-.. JRG: Note previous iterations of this section showed a hypothetical command
-   that knew how to map [build-system] dependencies to the system package manager.
-   This is NOT available in pyproject-external or the mappings, so I have removed it.
 
 .. code:: bash
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1004,7 +1004,7 @@ While a central authority for the registry is useful, the maintenance burden
 of handling the mappings for multiple ecosystems is unfeasible at the scale of PyPI.
 Hence, we propose that the central authority only governs the central registry and
 the list of known ecosystems, while the maintenance of the mappings themselves is handled
-by the target ecosystems. More details are given in Rationale and Governance.
+by the target ecosystems.
 
 Allowing ecosystem-specific variants of packages
 ------------------------------------------------

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -50,16 +50,6 @@ this PEP, making Python packaging easier and more reliable. In addition, the
 authors envision other types of tools making use of this information; e.g.,
 dependency analysis tools like Repology_, Dependabot_ and libraries.io_.
 
-It is also common that other ecosystems redistribute Python projects with their own
-packaging system. While this is required for packages with compiled extensions, it
-is theoretically unnecessary for pure Python wheels. The mapping proposed in this PEP
-would allow downstream redistribution efforts to focus on the compiled packages and
-instead delegate pure wheels to Python packaging solutions directly.
-See https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/68,
-https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/103 and
-https://github.com/spack/spack/issues/28282#issuecomment-1562178367 for examples of
-discussions in this direction.
-
 
 Rationale
 =========
@@ -1047,6 +1037,47 @@ maintenance burden on the governance body.
 Hence, we choose to leave these details out of the central registry, and instead
 suggest external contributors to maintain their own mappings where they can
 annotate the identifiers with extra metadata via the free-form ``extra`` field.
+
+Mapping PyPI projects to repackaged counterparts in target ecosystems
+---------------------------------------------------------------------
+
+It is common that other ecosystems redistribute Python projects with their own
+packaging system. While this is required for packages with compiled extensions, it
+is theoretically unnecessary for pure Python wheels; the only need for this seems to
+be metadata translation. See https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/68,
+https://discuss.python.org/t/wanting-a-singular-packaging-tool-vision/21141/103 and
+https://github.com/spack/spack/issues/28282#issuecomment-1562178367 for examples of
+discussions in this direction.
+
+The proposals in this PEP do not consider PyPI -> *ecosystem* mappings, but
+the same schemas can be repurposed to that end. After all, it is trivial to build a PURL or
+``dep:`` URL from a PyPI name (e.g. ``numpy`` becomes ``pkg:pypi/numpy``). A hypothetical
+mapping maintainer could annotate their repackaging efforts with the source PURL identifier,
+and then use that metadata to generate compatible mappings, such as:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/jaimergp/external-metadata-mappings/main/schemas/external-mapping.schema.json",
+  "schema_version": 1,
+  "name": "PyPI packages in Ubuntu 24.04",
+  "description": "PyPI mapping for the Ubuntu 24.04 LTS (Noble) distro",
+  "mappings": [
+    {
+      "id": "dep:pypi/numpy",
+      "description": "The fundamental package for scientific computing with Python",
+      "specs": ["python3-numpy"],
+      "urls": {
+        "home": "https://numpy.org/"
+      }
+    }
+  ]
+}
+```
+
+Such a mapping would allow downstream redistribution efforts to focus on the
+compiled packages and instead delegate pure wheels to Python packaging
+solutions directly.
+
 
 Open Issues
 ===========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -635,7 +635,9 @@ The following examples illustrate how the name mapping mechanism may be used.
 Note that the ``py-show`` command is hypothetical; this could be a ``pip``
 command or implemented in a new tool with a different name.
 
-Say we have a Python package named ``my-cpp-pkg`` with a single extension
+.. JRG: Should we change this to use pyproject-external or leave it as a hypothethical CLI?
+
+Say we have a Python package named ``my-cxx-pkg`` with a single extension
 module, implemented in C++ and using Boost and ``pybind11``, plus
 ``meson-python`` as the build backend:
 
@@ -650,7 +652,7 @@ module, implemented in C++ and using Boost and ``pybind11``, plus
 
     [external]
     build-requires = [
-      "dep:virtual/compiler/cpp",
+      "dep:virtual/compiler/cxx",
       "dep:generic/boost",
     ]
 
@@ -666,7 +668,7 @@ following:
 
     $ # show all external dependencies
     $ py-show --external
-    dep:virtual/compiler/cpp
+    dep:virtual/compiler/cxx
     dep:generic/boost
 
     $ # show how to install external dependencies
@@ -693,7 +695,7 @@ missing. If we get a build failure, the output may look like:
     This package has the following external dependencies, if those are missing
     on your system they are likely to be the cause of this build failure:
 
-      dep:virtual/compiler/cpp
+      dep:virtual/compiler/cxx
       dep:generic/boost
 
 If Pip has implemented support for querying the name mapping registry, the end
@@ -727,12 +729,12 @@ can now run Grayskull_:
 
 .. code::
 
-    $ grayskull pypi my-cpp-pkg
-    #### Initializing recipe for my-cpp-pkg (pypi) ####
+    $ grayskull pypi my-cxx-pkg
+    #### Initializing recipe for my-cxx-pkg (pypi) ####
 
     Recovering metadata from pypi...
-    Starting the download of the sdist package my-cpp-pkg
-    my-cpp-pkg 100% Time:  0:00:10   5.3 MiB/s|###########|
+    Starting the download of the sdist package my-cxx-pkg
+    my-cxx-pkg 100% Time:  0:00:10   5.3 MiB/s|###########|
     Checking for pyproject.toml
     ...
 
@@ -753,7 +755,7 @@ can now run Grayskull_:
     Run requirements:
       - python
 
-    #### Recipe generated on /path/to/recipe/dir for my-cpp-pkg ####
+    #### Recipe generated on /path/to/recipe/dir for my-cxx-pkg ####
 
 
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -997,7 +997,7 @@ For (3), a collection of example mappings for a sample of packages can be found 
 
 The JSON Schemas are created with `this Pydantic model <https://github.com/jaimergp/external-metadata-mappings/blob/main/schemas/schema.py>`__.
 
-The reference Python API to consume the different JSON documents and ``[external]`` tables
+The reference CLI and Python API to consume the different JSON documents and ``[external]`` tables
 can be found in `pyproject-external <https://github.com/jaimergp/pyproject-external>`__.
 
 Rejected Ideas

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -197,10 +197,10 @@ would provide ``dep:virtual/compiler/c``). Entries without ``provides`` content
 or, if populated, only with ``dep:virtual/`` identifiers, are considered
 canonical. The ``provides`` field MUST NOT be present in ``dep:virtual/`` definitions.
 
-Having a central registry enables client-side validation of the ``[external]``
-table of any given project. Tools SHOULD disallow ``dep:`` identifiers
-that are not included in the central registry and SHOULD recommend using the
-canonical form instead of a secondary alias.
+Having a central registry enables the validation of the ``[external]`` table.
+Tools MUST check that the provided identifiers are well formed. They MAY
+disallow ``dep:`` identifiers that are not included in the central registry,
+and SHOULD recommend using the canonical form instead of a secondary alias.
 
 The list of known ecosystems assigns an identifier to each ecosystem and reports the
 canonical location for its mapping. The mappings specify which ecosystem-specific
@@ -1075,6 +1075,25 @@ Such a mapping would allow downstream redistribution efforts to focus on the
 compiled packages and instead delegate pure wheels to Python packaging
 solutions directly.
 
+Strict validation of identifiers
+--------------------------------
+
+With the central registry, tools could choose to reject ``[external]`` metadata
+entries that do not conform to the well-known identifiers. We have decided not to
+enforce this and instead suggest to simply warn about it.
+
+It is expected that as the ``[external]`` metadata tables are adopted by the
+packaging community, the *canonical* identifier list grows to accommodate the
+requirements found in different projects. For example, a new C++ library or a
+new language compiler are introduced.
+
+If validation is made too strict and rejects unknown identifiers, this would
+introduce unnecessary friction in the external metadata adoption, and require
+human interaction to review and accept the newly requested identifiers.
+
+We suggest simply checking that the provided identifiers are well-formed. Future
+work may choose to also enforce that the identifiers are recognized as canonical,
+once the central registry has matured with significant adoption.
 
 Open Issues
 ===========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -775,7 +775,7 @@ recommend using the canonical form instead of a secondary alias. The
 pyproject-external API
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The proposed Python API also allows users to do these operations programmatically:
+The ``pyproject-external`` Python API also allows users to do these operations programmatically:
 
 .. code-block:: python
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -680,6 +680,10 @@ plus ``meson-python`` as the build backend:
 With complete name mappings for ``apt`` on Ubuntu, this may then show the
 following:
 
+.. JRG: Note previous iterations of this section showed a hypothetical command
+   that knew how to map [build-system] dependencies to the system package manager.
+   This is NOT available in pyproject-external or the mappings, so I have removed it.
+
 .. code:: bash
 
     # show all external dependencies as dep: URLs

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -564,6 +564,10 @@ Each entry in this list is defined as:
       - ``DepURLField`` (``string`` matching regex ``^dep:.+$``)
       - Take specs from another mapping entry.
       - Either ``specs`` or ``specs_from`` MUST be present.
+    * - ``extra``
+      - ``dict[NonEmptyString, Any]``
+      - Free-form key-value store for arbitrary metadata.
+      - False
 
 ``package_managers``
 ~~~~~~~~~~~~~~~~~~~~
@@ -1027,6 +1031,22 @@ may still choose to use it, but tools may warn about it and suggest using the
 generic one. This is meant to encourage ecosystem agnostic metadata whenever
 possible to facilitate adoption across platforms and operating systems.
 
+Adding more package metadata to the central registry
+----------------------------------------------------
+
+A central registry should only contain a list of ``dep:`` URLs and a
+minimal set of metadata fields to facilitate its identification (a free-form
+text description, and one or more URLs to relevant locations).
+
+These fields should be enough to identify the project home,
+where that extra metadata can be obtained (e.g. the repository URL will likely
+include details about authorship and licensing). Also, those details may change
+over the lifetime of the project, and keeping them up-to-date would increase the
+maintenance burden on the governance body.
+
+Hence, we choose to leave these details out of the central registry, and instead
+suggest external contributors to maintain their own mappings where they can
+annotate the identifiers with extra metadata via the free-form ``extra`` field.
 
 Open Issues
 ===========

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -552,7 +552,7 @@ Each entry in this list is defined as:
       - ``DepURLField`` (``string`` matching regex ``^dep:.+$``)
       - Take specs from another mapping entry.
       - Either ``specs`` or ``specs_from`` MUST be present.
-    * - ``extra``
+    * - ``extra_metadata``
       - ``dict[NonEmptyString, Any]``
       - Free-form key-value store for arbitrary metadata.
       - False
@@ -1018,7 +1018,7 @@ text description, and one or more URLs to relevant locations).
 
 We have chosen to leave additional details out of the central registry, and instead
 suggest external contributors to maintain their own mappings where they can
-annotate the identifiers with extra metadata via the free-form ``extra`` field.
+annotate the identifiers with extra metadata via the free-form ``extra_metadata`` field.
 
 The reasons include:
 

--- a/peps/pep-9999.rst
+++ b/peps/pep-9999.rst
@@ -1006,7 +1006,7 @@ Some ecosystems have their own variants of known packages; e.g. Debian's
 is syntactically valid, the central registry should not recognize it as a
 well-known identifier, preferring its ``generic`` counterpart instead. Users
 may still choose to use it, but tools may warn about it and suggest using the
-generic one. This is meant to encourage ecosystem agnostic metadata whenever
+generic one. This is meant to encourage ecosystem-agnostic metadata whenever
 possible to facilitate adoption across platforms and operating systems.
 
 Adding more package metadata to the central registry
@@ -1026,7 +1026,7 @@ The reasons include:
   where that extra metadata can be obtained (e.g. the repository at the URL will likely
   include details about authorship and licensing).
 - These details can also be obtained from the actual target ecosystems. In some
-  cases this might be even preferable; e.g. for licenses, where downstream packaging
+  cases this might even be preferable; e.g., for licenses, where downstream packaging
   can actually affect it by unvendoring dependencies or adjusting optional bits.
 - Those details may change over the lifetime of the project, and keeping them
   up-to-date would increase the maintenance burden on the governance body.
@@ -1085,11 +1085,13 @@ enforce this and instead suggest to simply warn about it.
 It is expected that as the ``[external]`` metadata tables are adopted by the
 packaging community, the *canonical* identifier list grows to accommodate the
 requirements found in different projects. For example, a new C++ library or a
-new language compiler are introduced.
+new compiler are introduced.
 
 If validation is made too strict and rejects unknown identifiers, this would
 introduce unnecessary friction in the external metadata adoption, and require
-human interaction to review and accept the newly requested identifiers.
+human interaction to review and accept the newly requested identifiers in
+a time-critical manner, potentially blocking publication of the package
+that needs a new identifier added to the central registry.
 
 We suggest simply checking that the provided identifiers are well-formed. Future
 work may choose to also enforce that the identifiers are recognized as canonical,


### PR DESCRIPTION
Based on https://github.com/rgommers/peps/pull/39 branch. That one should be merged before this one. This PR's commits start at ba446f6f9782f4b22ea26e57a5998b384bec8ec6.

Goes with https://github.com/jaimergp/external-metadata-mappings/pull/16.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--43.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->